### PR TITLE
Add support for other proprietary Mailchimp attrs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,10 @@ exports = module.exports = function (input) {
     throw new Error('invalid input for mailchimpify');
   }
 
-  return input.replace(/data-mc-edit/g, 'mc:edit');
+  return input
+    .replace(/data-mc-edit/g, 'mc:edit')
+    .replace(/data-mc-hideable/g, 'mc:hideable')
+    .replace(/data-mc-repeatable/g, 'mc:repeatable')
+    .replace(/data-mc-variant/g, 'mc:variant')
+    .replace(/data-mc-label/g, 'mc:label');
 };

--- a/test.js
+++ b/test.js
@@ -9,6 +9,39 @@ test('should replace `data-mc-edit` tags with `mc:edit`', function (t) {
   t.end();
 });
 
+test('should replace other special tags', function (t) {
+  t.equal(mailchimpify('<div data-mc-hideable>mybar</div>'),
+    '<div mc:hideable>mybar</div>');
+
+  t.equal(mailchimpify('<p data-mc-repeatable="F"></p>'),
+    '<p mc:repeatable="F"></p>');
+
+  t.equal(mailchimpify('<p data-mc-variant="A"></p>'),
+    '<p mc:variant="A"></p>');
+
+  t.equal(mailchimpify('<p data-mc-label="B"></p>'),
+    '<p mc:label="B"></p>');
+
+  t.end();
+});
+
+test('should handle multiple replacements, but only valid ones', function (t) {
+  var str = '<div data-mc-label="A" data-mc-hideable>' +
+              '<div data-mc-nope="B" data-mc-variant="C">' +
+                '<div data-mc-label="D"/>' +
+              '</div>' +
+            '</div>';
+
+  var result = mailchimpify(str);
+
+  t.equal(result, '<div mc:label="A" mc:hideable>' +
+                    '<div data-mc-nope="B" mc:variant="C">' +
+                      '<div mc:label="D"/>' +
+                    '</div>' +
+                  '</div>');
+  t.end();
+});
+
 test('should return exact string if no `data-mc-edit` is present', function (t) {
   var str = 'foo';
   var expected = 'foo';


### PR DESCRIPTION
Noticed this module only replaced `mc:edit`, when in fact there are a handful more attributes that Mailchimp supports. 

See this doc for reference: 

https://templates.mailchimp.com/getting-started/template-language/